### PR TITLE
feat: simplify env config, add dev:prod script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,3 @@
-# Public (exposed to browser)
-NEXT_PUBLIC_API_URL=http://localhost:3000
-NEXT_PUBLIC_SITE_URL=http://localhost:3002
+NEXT_PUBLIC_API_URL=https://api.example.com
+NEXT_PUBLIC_SITE_URL=https://example.com
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_xxx
-
-# Server-only (never sent to browser)
-API_URL=http://localhost:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
       NEXT_PUBLIC_API_URL: https://ci.example.com
       NEXT_PUBLIC_SITE_URL: https://ci.example.com
       NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_ci_placeholder
-      API_URL: https://ci.example.com
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,9 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files
-.env*.local
 .env
+.env.*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -132,14 +132,17 @@ cd nextjs-ecommerce-store
 pnpm install
 
 # Configure environment
-cp .env.example .env
-# Edit .env — set API URLs and Stripe publishable key
+cp .env.example .env.development
+# Edit .env.development — set API URLs and Stripe publishable key
 
 # Generate API client from backend Swagger spec
 pnpm api:generate
 
-# Start development server
+# Start development server (uses local backend)
 pnpm dev
+
+# Or start against production API
+pnpm dev:prod
 ```
 
 The store runs on **`http://localhost:3002`**.
@@ -148,23 +151,24 @@ The store runs on **`http://localhost:3002`**.
 
 ## Scripts
 
-| Command              | Description                                       |
-| -------------------- | ------------------------------------------------- |
-| `pnpm dev`           | Start Next.js dev server (port 3002)              |
-| `pnpm build`         | Generate API client + Next.js production build    |
-| `pnpm start`         | Run production build (port 3002)                  |
-| `pnpm lint`          | ESLint checks                                     |
-| `pnpm format`        | Prettier format all files                         |
-| `pnpm format:check`  | Check formatting without writing                  |
-| `pnpm typecheck`     | TypeScript type checking only                     |
-| `pnpm api:generate`  | Generate API client from backend OpenAPI spec     |
-| `pnpm test`          | Run unit tests (Vitest, watch mode)               |
-| `pnpm test:run`      | Run unit tests (single run)                       |
-| `pnpm test:coverage` | Generate coverage report                          |
-| `pnpm test:e2e`      | Run Playwright E2E tests                          |
-| `pnpm test:e2e:ui`   | Run E2E tests with Playwright UI                  |
-| `pnpm validate`      | Run all checks (lint, format, types, test, build) |
-| `pnpm analyze`       | Build with bundle analyzer                        |
+| Command              | Description                                             |
+| -------------------- | ------------------------------------------------------- |
+| `pnpm dev`           | Start Next.js dev server with local backend (port 3002) |
+| `pnpm dev:prod`      | Start Next.js dev server with production backend        |
+| `pnpm build`         | Generate API client + Next.js production build          |
+| `pnpm start`         | Run production build (port 3002)                        |
+| `pnpm lint`          | ESLint checks                                           |
+| `pnpm format`        | Prettier format all files                               |
+| `pnpm format:check`  | Check formatting without writing                        |
+| `pnpm typecheck`     | TypeScript type checking only                           |
+| `pnpm api:generate`  | Generate API client from backend OpenAPI spec           |
+| `pnpm test`          | Run unit tests (Vitest, watch mode)                     |
+| `pnpm test:run`      | Run unit tests (single run)                             |
+| `pnpm test:coverage` | Generate coverage report                                |
+| `pnpm test:e2e`      | Run Playwright E2E tests                                |
+| `pnpm test:e2e:ui`   | Run E2E tests with Playwright UI                        |
+| `pnpm validate`      | Run all checks (lint, format, types, test, build)       |
+| `pnpm analyze`       | Build with bundle analyzer                              |
 
 ---
 
@@ -259,12 +263,16 @@ GitHub Actions runs **5 parallel jobs** on every PR and push to main:
 
 See [`.env.example`](.env.example) for all required variables.
 
-| Variable                             | Description               | Default                 |
-| ------------------------------------ | ------------------------- | ----------------------- |
-| `NEXT_PUBLIC_API_URL`                | Backend API URL (browser) | `http://localhost:3000` |
-| `NEXT_PUBLIC_SITE_URL`               | Store URL                 | `http://localhost:3002` |
-| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key    | —                       |
-| `API_URL`                            | Backend API URL (server)  | `http://localhost:3000` |
+| Variable                             | Description            |
+| ------------------------------------ | ---------------------- |
+| `NEXT_PUBLIC_API_URL`                | Backend API URL        |
+| `NEXT_PUBLIC_SITE_URL`               | Store URL (for SEO)    |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key |
+
+| File               | Mode                     | API Target                   |
+| ------------------ | ------------------------ | ---------------------------- |
+| `.env.development` | `pnpm dev`               | Local backend (localhost)    |
+| `.env.production`  | `pnpm dev:prod` / Vercel | Production backend (Railway) |
 
 All environment variables are validated at build time via Zod. The app will not build with missing or invalid configuration.
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
     "dev": "next dev --port 3002",
+    "dev:prod": "dotenv -e .env.production -- next dev --port 3002",
     "prebuild": "openapi-ts",
     "build": "next build",
     "start": "next start --port 3002",
@@ -83,6 +84,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.1",
     "babel-plugin-react-compiler": "1.0.0",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.7",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
+      dotenv-cli:
+        specifier: ^11.0.0
+        version: 11.0.0
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
@@ -1806,6 +1809,18 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dotenv-cli@11.0.0:
+    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
+    hasBin: true
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -5617,6 +5632,19 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dotenv-cli@11.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 17.3.1
+      dotenv-expand: 12.0.3
+      minimist: 1.2.8
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.6.1
+
+  dotenv@16.6.1: {}
 
   dotenv@17.3.1: {}
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,34 +1,21 @@
 import { z } from 'zod';
 
-const clientEnvSchema = z.object({
+const envSchema = z.object({
   NEXT_PUBLIC_API_URL: z.url(),
   NEXT_PUBLIC_SITE_URL: z.url(),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().startsWith('pk_'),
 });
 
-const serverEnvSchema = clientEnvSchema.extend({
-  API_URL: z.url(),
-});
-
-const isServer = typeof window === 'undefined';
-
-const rawEnv = {
+const parsed = envSchema.safeParse({
   NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
   NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
     process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
-  ...(isServer ? { API_URL: process.env.API_URL } : {}),
-};
-
-const parsed = isServer
-  ? serverEnvSchema.safeParse(rawEnv)
-  : clientEnvSchema.safeParse(rawEnv);
+});
 
 if (!parsed.success) {
   console.error('Invalid environment variables:', parsed.error.flatten());
-  throw new Error(
-    `Invalid environment variables. Check ${isServer ? 'server logs' : 'browser console'}.`,
-  );
+  throw new Error('Invalid environment variables');
 }
 
 export const env = parsed.data;


### PR DESCRIPTION
## Summary
- Remove unused server-only `API_URL` variable, simplify env validation
- Add `dev:prod` script to run local dev server against production API (via `dotenv-cli`)
- Update `.gitignore` to ignore all `.env.*` except `.env.example`
- Update `.env.example` with placeholder URLs
- Remove `API_URL` from CI build env
- Update README with environment configuration docs