### PR TITLE
fix: resolve 4 high-priority bugs (#72, #64, #73, #71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ A production-ready **customer-facing ecommerce storefront** built with Next.js 1
 - Shipping method selection with pricing
 - Order review with itemized totals (subtotal, tax, shipping, discounts)
 - Stripe payment integration with PaymentIntent
+- Navigation guard prevents accidental page leave during payment
 - Success and failure result pages
 
 ### Authentication & Account
 
 - Register, login, logout with JWT access/refresh tokens
-- Email verification with tokenized links
+- Email verification with tokenized links (context-aware post-verification redirect)
 - Password reset flow (forgot password, reset with token)
 - Silent refresh on app load (seamless page reload)
 - Multi-tab session sync via BroadcastChannel
@@ -65,8 +66,11 @@ A production-ready **customer-facing ecommerce storefront** built with Next.js 1
 ### Orders
 
 - Order history with status filtering and pagination
-- Order detail — items, shipping address, financial summary
+- Order detail — items, shipping address, financial summary, payment status
 - Order status timeline visualization
+- "Pay Now" button to resume payment on unpaid orders
+- 24-hour expiration warning with countdown for unpaid orders
+- "Awaiting Payment" badge on order list for pending orders
 - Cancel orders (PENDING/CONFIRMED only)
 - Refund request flow
 

--- a/src/components/auth/verify-email-content.tsx
+++ b/src/components/auth/verify-email-content.tsx
@@ -12,6 +12,8 @@ export const VerifyEmailContent = () => {
   const token = searchParams.get('token');
   const calledRef = useRef(false);
   const accessToken = useAuthStore((s) => s.accessToken);
+  const isHydrated = useAuthStore((s) => s.isHydrated);
+  const isAuthenticated = isHydrated && !!accessToken;
 
   const verifyMutation = useMutation({
     mutationFn: async () => {
@@ -64,11 +66,11 @@ export const VerifyEmailContent = () => {
       <>
         <h1 className='text-2xl font-bold tracking-tight'>Email Verified!</h1>
         <p className='text-muted-foreground text-sm'>
-          {accessToken
+          {isAuthenticated
             ? 'Your email has been verified successfully.'
             : 'Your email has been verified successfully. You can now sign in.'}
         </p>
-        {accessToken ? (
+        {isAuthenticated ? (
           <Link
             href='/'
             className='bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm font-medium transition-colors'

--- a/src/components/auth/verify-email-content.tsx
+++ b/src/components/auth/verify-email-content.tsx
@@ -5,11 +5,13 @@ import { useMutation } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { authControllerVerifyEmail } from '@/api/generated/sdk.gen';
+import { useAuthStore } from '@/stores/auth.store';
 
 export const VerifyEmailContent = () => {
   const searchParams = useSearchParams();
   const token = searchParams.get('token');
   const calledRef = useRef(false);
+  const accessToken = useAuthStore((s) => s.accessToken);
 
   const verifyMutation = useMutation({
     mutationFn: async () => {
@@ -62,14 +64,25 @@ export const VerifyEmailContent = () => {
       <>
         <h1 className='text-2xl font-bold tracking-tight'>Email Verified!</h1>
         <p className='text-muted-foreground text-sm'>
-          Your email has been verified successfully. You can now sign in.
+          {accessToken
+            ? 'Your email has been verified successfully.'
+            : 'Your email has been verified successfully. You can now sign in.'}
         </p>
-        <Link
-          href='/login'
-          className='bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm font-medium transition-colors'
-        >
-          Sign In
-        </Link>
+        {accessToken ? (
+          <Link
+            href='/'
+            className='bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm font-medium transition-colors'
+          >
+            Continue Shopping
+          </Link>
+        ) : (
+          <Link
+            href='/login'
+            className='bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm font-medium transition-colors'
+          >
+            Sign In
+          </Link>
+        )}
       </>
     );
   }

--- a/src/components/checkout/payment-page.tsx
+++ b/src/components/checkout/payment-page.tsx
@@ -63,11 +63,24 @@ export const PaymentPage = ({ orderId }: PaymentPageProps) => {
     staleTime: Infinity,
   });
 
+  const clientSecret = intentData?.data?.data?.clientSecret;
+
   useEffect(() => {
     if (isIntentError && intentError) {
       toast.error(getErrorMessage(intentError));
     }
   }, [isIntentError, intentError]);
+
+  useEffect(() => {
+    if (!clientSecret) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [clientSecret]);
 
   if (!isHydrated) {
     return (
@@ -79,7 +92,6 @@ export const PaymentPage = ({ orderId }: PaymentPageProps) => {
 
   if (!accessToken) return null;
 
-  const clientSecret = intentData?.data?.data?.clientSecret;
   const order = orderData?.data?.data;
 
   const isLoading = isOrderLoading || isIntentLoading;

--- a/src/components/checkout/payment-page.tsx
+++ b/src/components/checkout/payment-page.tsx
@@ -76,6 +76,8 @@ export const PaymentPage = ({ orderId }: PaymentPageProps) => {
 
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       e.preventDefault();
+      // Deprecated but required for Chrome/Safari to show the confirmation dialog
+      e.returnValue = '';
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);

--- a/src/components/orders/order-detail-page.tsx
+++ b/src/components/orders/order-detail-page.tsx
@@ -5,10 +5,15 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useQuery } from '@tanstack/react-query';
-import { ArrowLeftIcon } from '@phosphor-icons/react';
-import { ordersControllerGetMyOrderByIdOptions } from '@/api/generated/@tanstack/react-query.gen';
+import { ArrowLeftIcon, WarningCircleIcon } from '@phosphor-icons/react';
+import {
+  ordersControllerGetMyOrderByIdOptions,
+  paymentsControllerGetPaymentByOrderIdOptions,
+} from '@/api/generated/@tanstack/react-query.gen';
 import { useAuthStore } from '@/stores/auth.store';
 import { formatPrice } from '@/lib/format';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -35,6 +40,14 @@ const OrderDetailPage = ({ orderId }: OrderDetailPageProps) => {
       path: { id: orderId },
     }),
     enabled: !!accessToken,
+  });
+
+  const { data: paymentData } = useQuery({
+    ...paymentsControllerGetPaymentByOrderIdOptions({
+      path: { orderId },
+    }),
+    enabled: !!accessToken,
+    retry: false,
   });
 
   if (!isHydrated) {
@@ -75,8 +88,21 @@ const OrderDetailPage = ({ orderId }: OrderDetailPageProps) => {
   }
 
   const order = data?.data;
+  const payment = paymentData?.data;
 
   if (!order) return null;
+
+  const isUnpaid =
+    order.status === 'PENDING' && payment?.status !== 'SUCCEEDED';
+  const expiresAt = new Date(
+    new Date(order.createdAt).getTime() + 24 * 60 * 60 * 1000,
+  );
+  const now = new Date();
+  const msRemaining = expiresAt.getTime() - now.getTime();
+  const hoursRemaining = Math.floor(msRemaining / (1000 * 60 * 60));
+  const minutesRemaining = Math.floor(
+    (msRemaining % (1000 * 60 * 60)) / (1000 * 60),
+  );
 
   const couponCode = order.couponCode;
   const shippingRegion = order.shippingRegion;
@@ -107,6 +133,54 @@ const OrderDetailPage = ({ orderId }: OrderDetailPageProps) => {
       <div className='mb-6'>
         <OrderStatusTimeline status={order.status} />
       </div>
+
+      {payment && (
+        <div className='mb-6 flex items-center gap-2'>
+          <span className='text-sm font-medium'>Payment:</span>
+          <Badge
+            variant={
+              payment.status === 'SUCCEEDED'
+                ? 'default'
+                : payment.status === 'FAILED'
+                  ? 'destructive'
+                  : 'secondary'
+            }
+          >
+            {payment.status === 'SUCCEEDED' && 'Paid'}
+            {payment.status === 'PENDING' && 'Pending'}
+            {payment.status === 'FAILED' && 'Failed'}
+            {payment.status === 'REFUND_PENDING' && 'Refund Pending'}
+            {payment.status === 'REFUNDED' && 'Refunded'}
+            {payment.status === 'PARTIALLY_REFUNDED' && 'Partially Refunded'}
+          </Badge>
+        </div>
+      )}
+
+      {isUnpaid && (
+        <div className='mb-6 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-50 p-4 dark:bg-amber-950/20'>
+          <WarningCircleIcon
+            size={20}
+            className='mt-0.5 shrink-0 text-amber-600'
+          />
+          <div className='text-sm'>
+            {msRemaining <= 0 ? (
+              <p className='text-destructive font-medium'>
+                This order has expired and will be cancelled.
+              </p>
+            ) : (
+              <p className='text-amber-800 dark:text-amber-200'>
+                This order will be automatically cancelled if not paid within 24
+                hours.{' '}
+                <span className='font-medium'>
+                  {hoursRemaining > 0
+                    ? `${hoursRemaining}h ${minutesRemaining}m remaining.`
+                    : `${minutesRemaining}m remaining.`}
+                </span>
+              </p>
+            )}
+          </div>
+        </div>
+      )}
 
       <Card className='mb-6 p-6'>
         <h2 className='mb-4 text-lg font-semibold'>Items</h2>
@@ -185,7 +259,17 @@ const OrderDetailPage = ({ orderId }: OrderDetailPageProps) => {
         </div>
       </Card>
 
-      <OrderActions orderId={orderId} status={order.status} />
+      <div className='flex gap-3'>
+        {isUnpaid && msRemaining > 0 && (
+          <Button
+            nativeButton={false}
+            render={<Link href={`/checkout/payment/${orderId}`} />}
+          >
+            Pay Now
+          </Button>
+        )}
+        <OrderActions orderId={orderId} status={order.status} />
+      </div>
     </div>
   );
 };

--- a/src/components/orders/order-list-card.tsx
+++ b/src/components/orders/order-list-card.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import type { OrderListDto } from '@/api/generated/types.gen';
 import { formatPrice } from '@/lib/format';
+import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { OrderStatusBadge } from '@/components/orders/order-status-badge';
 
@@ -27,6 +28,14 @@ const OrderListCard = ({ order }: OrderListCardProps) => {
         <div className='flex items-center gap-4'>
           <p className='font-medium'>{formatPrice(order.total)}</p>
           <OrderStatusBadge status={order.status} />
+          {order.status === 'PENDING' && (
+            <Badge
+              variant='outline'
+              className='border-amber-500 text-amber-600'
+            >
+              Awaiting Payment
+            </Badge>
+          )}
         </div>
       </Card>
     </Link>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useId } from 'react';
 import { Button as ButtonPrimitive } from '@base-ui/react/button';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -44,11 +45,14 @@ function Button({
   className,
   variant = 'default',
   size = 'default',
+  id,
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  const generatedId = useId();
   return (
     <ButtonPrimitive
       data-slot='button'
+      id={id ?? generatedId}
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import * as React from 'react';
-import { useId } from 'react';
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 
 import { cn } from '@/lib/utils';
@@ -118,7 +117,7 @@ function DialogFooter({
 }
 
 function DialogTitle({ className, id, ...props }: DialogPrimitive.Title.Props) {
-  const generatedId = useId();
+  const generatedId = React.useId();
   return (
     <DialogPrimitive.Title
       data-slot='dialog-title'
@@ -134,7 +133,7 @@ function DialogDescription({
   id,
   ...props
 }: DialogPrimitive.Description.Props) {
-  const generatedId = useId();
+  const generatedId = React.useId();
   return (
     <DialogPrimitive.Description
       data-slot='dialog-description'

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { useId } from 'react';
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 
 import { cn } from '@/lib/utils';
@@ -116,10 +117,12 @@ function DialogFooter({
   );
 }
 
-function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+function DialogTitle({ className, id, ...props }: DialogPrimitive.Title.Props) {
+  const generatedId = useId();
   return (
     <DialogPrimitive.Title
       data-slot='dialog-title'
+      id={id ?? generatedId}
       className={cn('text-sm font-medium', className)}
       {...props}
     />
@@ -128,11 +131,14 @@ function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
 
 function DialogDescription({
   className,
+  id,
   ...props
 }: DialogPrimitive.Description.Props) {
+  const generatedId = useId();
   return (
     <DialogPrimitive.Description
       data-slot='dialog-description'
+      id={id ?? generatedId}
       className={cn(
         'text-xs/relaxed text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
         className,

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,14 +1,22 @@
 'use client';
 
 import * as React from 'react';
+import { useId } from 'react';
 import { Input as InputPrimitive } from '@base-ui/react/input';
 
 import { cn } from '@/lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+function Input({
+  className,
+  type,
+  id,
+  ...props
+}: React.ComponentProps<'input'>) {
+  const generatedId = useId();
   return (
     <InputPrimitive
       type={type}
+      id={id ?? generatedId}
       data-slot='input'
       className={cn(
         'h-8 w-full min-w-0 rounded-none border border-input bg-transparent px-2.5 py-1 text-xs transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-xs file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 md:text-xs dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import * as React from 'react';
-import { useId } from 'react';
 import { Input as InputPrimitive } from '@base-ui/react/input';
 
 import { cn } from '@/lib/utils';
@@ -12,7 +11,7 @@ function Input({
   id,
   ...props
 }: React.ComponentProps<'input'>) {
-  const generatedId = useId();
+  const generatedId = React.useId();
   return (
     <InputPrimitive
       type={type}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import * as React from 'react';
-import { useId } from 'react';
 import { Dialog as SheetPrimitive } from '@base-ui/react/dialog';
 
 import { cn } from '@/lib/utils';
@@ -101,7 +100,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 function SheetTitle({ className, id, ...props }: SheetPrimitive.Title.Props) {
-  const generatedId = useId();
+  const generatedId = React.useId();
   return (
     <SheetPrimitive.Title
       data-slot='sheet-title'
@@ -117,7 +116,7 @@ function SheetDescription({
   id,
   ...props
 }: SheetPrimitive.Description.Props) {
-  const generatedId = useId();
+  const generatedId = React.useId();
   return (
     <SheetPrimitive.Description
       data-slot='sheet-description'

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { useId } from 'react';
 import { Dialog as SheetPrimitive } from '@base-ui/react/dialog';
 
 import { cn } from '@/lib/utils';
@@ -99,10 +100,12 @@ function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
+function SheetTitle({ className, id, ...props }: SheetPrimitive.Title.Props) {
+  const generatedId = useId();
   return (
     <SheetPrimitive.Title
       data-slot='sheet-title'
+      id={id ?? generatedId}
       className={cn('text-sm font-medium text-foreground', className)}
       {...props}
     />
@@ -111,11 +114,14 @@ function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
 
 function SheetDescription({
   className,
+  id,
   ...props
 }: SheetPrimitive.Description.Props) {
+  const generatedId = useId();
   return (
     <SheetPrimitive.Description
       data-slot='sheet-description'
+      id={id ?? generatedId}
       className={cn('text-xs/relaxed text-muted-foreground', className)}
       {...props}
     />

--- a/src/lib/__tests__/api-error.test.ts
+++ b/src/lib/__tests__/api-error.test.ts
@@ -29,7 +29,30 @@ describe('getErrorMessage', () => {
     expect(getErrorMessage(42)).toBe(DEFAULT_MESSAGE);
   });
 
-  it('should return default message when given a plain object', () => {
-    expect(getErrorMessage({ message: 'hidden' })).toBe(DEFAULT_MESSAGE);
+  it('should return message from a plain object with message property', () => {
+    expect(getErrorMessage({ message: 'hidden' })).toBe('hidden');
+  });
+
+  it('should return message from an API error response object', () => {
+    expect(
+      getErrorMessage({
+        success: false,
+        statusCode: 400,
+        message: 'You must purchase this product before reviewing',
+        error: 'Bad Request',
+      }),
+    ).toBe('You must purchase this product before reviewing');
+  });
+
+  it('should return default message when object has empty message', () => {
+    expect(getErrorMessage({ message: '' })).toBe(DEFAULT_MESSAGE);
+  });
+
+  it('should return default message when object has non-string message', () => {
+    expect(getErrorMessage({ message: 42 })).toBe(DEFAULT_MESSAGE);
+  });
+
+  it('should return default message when object has no message property', () => {
+    expect(getErrorMessage({ code: 'ERR' })).toBe(DEFAULT_MESSAGE);
   });
 });

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,7 +1,17 @@
 const DEFAULT_ERROR_MESSAGE = 'Something went wrong. Please try again.';
 
+const isObjectWithMessage = (error: unknown): error is { message: string } =>
+  typeof error === 'object' &&
+  error !== null &&
+  'message' in error &&
+  typeof (error as Record<string, unknown>).message === 'string';
+
 export const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error) {
+    return error.message || DEFAULT_ERROR_MESSAGE;
+  }
+
+  if (isObjectWithMessage(error)) {
     return error.message || DEFAULT_ERROR_MESSAGE;
   }
 


### PR DESCRIPTION
## Summary

- **#72** — `getErrorMessage()` now extracts messages from plain API error objects, fixing generic "Something went wrong" across ~20+ locations
- **#64** — Verify email page shows "Continue Shopping" when user is already authenticated instead of misleading "Sign In"
- **#73** — Pass stable `useId()` to Base UI primitives (Button, Input, Sheet, Dialog) to prevent SSR/client hydration mismatch
- **#71** — Add payment status badge, "Pay Now" button, 24h expiration warning on order detail; "Awaiting Payment" badge on order list; `beforeunload` navigation guard on payment page

Closes #72, closes #64, closes #73, closes #71